### PR TITLE
Swifty method name

### DIFF
--- a/Pod/Classes/ABLayoutAnchor/ABLayoutAnchor.h
+++ b/Pod/Classes/ABLayoutAnchor/ABLayoutAnchor.h
@@ -30,15 +30,15 @@ NS_ASSUME_NONNULL_BEGIN
 
 /* These methods return an inactive constraint of the form thisAnchor = otherAnchor.
  */
-- (NSLayoutConstraint *)constraintEqualToAnchor:(ABLayoutAnchor<AnchorType> *)anchor;
-- (NSLayoutConstraint *)constraintGreaterThanOrEqualToAnchor:(ABLayoutAnchor<AnchorType> *)anchor;
-- (NSLayoutConstraint *)constraintLessThanOrEqualToAnchor:(ABLayoutAnchor<AnchorType> *)anchor;
+- (NSLayoutConstraint *)constraintEqualToAnchor:(ABLayoutAnchor<AnchorType> *)anchor NS_SWIFT_NAME( constraint(equalTo:) );
+- (NSLayoutConstraint *)constraintGreaterThanOrEqualToAnchor:(ABLayoutAnchor<AnchorType> *)anchor NS_SWIFT_NAME( constraint(greaterThanOrEqualTo:) );
+- (NSLayoutConstraint *)constraintLessThanOrEqualToAnchor:(ABLayoutAnchor<AnchorType> *)anchor NS_SWIFT_NAME( constraint(lessThanOrEqualTo:) );
 
 /* These methods return an inactive constraint of the form thisAnchor = otherAnchor + constant.
  */
-- (NSLayoutConstraint *)constraintEqualToAnchor:(ABLayoutAnchor<AnchorType> *)anchor constant:(CGFloat)c;
-- (NSLayoutConstraint *)constraintGreaterThanOrEqualToAnchor:(ABLayoutAnchor<AnchorType> *)anchor constant:(CGFloat)c;
-- (NSLayoutConstraint *)constraintLessThanOrEqualToAnchor:(ABLayoutAnchor<AnchorType> *)anchor constant:(CGFloat)c;
+- (NSLayoutConstraint *)constraintEqualToAnchor:(ABLayoutAnchor<AnchorType> *)anchor constant:(CGFloat)c NS_SWIFT_NAME( constraint(equalTo:constant:) );
+- (NSLayoutConstraint *)constraintGreaterThanOrEqualToAnchor:(ABLayoutAnchor<AnchorType> *)anchor constant:(CGFloat)c NS_SWIFT_NAME( constraint(greaterThanOrEqualTo:constant:) );
+- (NSLayoutConstraint *)constraintLessThanOrEqualToAnchor:(ABLayoutAnchor<AnchorType> *)anchor constant:(CGFloat)c NS_SWIFT_NAME( constraint(lessThanOrEqualTo:constant:) );
 
 @end
 
@@ -64,23 +64,23 @@ NS_ASSUME_NONNULL_BEGIN
 /* These methods return an inactive constraint of the form
  thisVariable = constant.
  */
-- (NSLayoutConstraint *)constraintEqualToConstant:(CGFloat)c;
-- (NSLayoutConstraint *)constraintGreaterThanOrEqualToConstant:(CGFloat)c;
-- (NSLayoutConstraint *)constraintLessThanOrEqualToConstant:(CGFloat)c;
+- (NSLayoutConstraint *)constraintEqualToConstant:(CGFloat)c NS_SWIFT_NAME( constraint(equalToConstant:) );
+- (NSLayoutConstraint *)constraintGreaterThanOrEqualToConstant:(CGFloat)c NS_SWIFT_NAME( constraint(greaterThanOrEqualeToConstant:) );
+- (NSLayoutConstraint *)constraintLessThanOrEqualToConstant:(CGFloat)c NS_SWIFT_NAME( constraint(lessThanOrEqualToConstant:) );
 
 /* These methods return an inactive constraint of the form
  thisAnchor = otherAnchor * multiplier.
  */
-- (NSLayoutConstraint *)constraintEqualToAnchor:(ABLayoutDimension *)anchor multiplier:(CGFloat)m;
-- (NSLayoutConstraint *)constraintGreaterThanOrEqualToAnchor:(ABLayoutDimension *)anchor multiplier:(CGFloat)m;
-- (NSLayoutConstraint *)constraintLessThanOrEqualToAnchor:(ABLayoutDimension *)anchor multiplier:(CGFloat)m;
+- (NSLayoutConstraint *)constraintEqualToAnchor:(ABLayoutDimension *)anchor multiplier:(CGFloat)m NS_SWIFT_NAME( constraint(equalTo:multiplier:) );
+- (NSLayoutConstraint *)constraintGreaterThanOrEqualToAnchor:(ABLayoutDimension *)anchor multiplier:(CGFloat)m NS_SWIFT_NAME( constraint(greaterThanOrEqualTo:multiplier:) );
+- (NSLayoutConstraint *)constraintLessThanOrEqualToAnchor:(ABLayoutDimension *)anchor multiplier:(CGFloat)m NS_SWIFT_NAME( constraint(lessThanOrEqualTo:multiplier:) );
 
 /* These methods return an inactive constraint of the form
  thisAnchor = otherAnchor * multiplier + constant.
  */
-- (NSLayoutConstraint *)constraintEqualToAnchor:(ABLayoutDimension *)anchor multiplier:(CGFloat)m constant:(CGFloat)c;
-- (NSLayoutConstraint *)constraintGreaterThanOrEqualToAnchor:(ABLayoutDimension *)anchor multiplier:(CGFloat)m constant:(CGFloat)c;
-- (NSLayoutConstraint *)constraintLessThanOrEqualToAnchor:(ABLayoutDimension *)anchor multiplier:(CGFloat)m constant:(CGFloat)c;
+- (NSLayoutConstraint *)constraintEqualToAnchor:(ABLayoutDimension *)anchor multiplier:(CGFloat)m constant:(CGFloat)c NS_SWIFT_NAME( constraint(equalTo:multiplier:constant:) );
+- (NSLayoutConstraint *)constraintGreaterThanOrEqualToAnchor:(ABLayoutDimension *)anchor multiplier:(CGFloat)m constant:(CGFloat)c NS_SWIFT_NAME( constraint(greaterThanOrEqualTo:multiplier:constant:) );
+- (NSLayoutConstraint *)constraintLessThanOrEqualToAnchor:(ABLayoutDimension *)anchor multiplier:(CGFloat)m constant:(CGFloat)c NS_SWIFT_NAME( constraint(lessThanOrEqualTo:multiplier:constant:) );
 
 @end
 

--- a/Pod/Classes/ABLayoutEdgesAnchor.h
+++ b/Pod/Classes/ABLayoutEdgesAnchor.h
@@ -36,16 +36,16 @@ typedef NS_OPTIONS(NSUInteger, ABLayoutEdgesAttribute) {
 /* These methods return an array of inactive constraints of the form
  thisVariable = constant.
  */
-- (NSArray<NSLayoutConstraint *> *)constraintsEqualToConstant:(UIEdgeInsets)c;
-- (NSArray<NSLayoutConstraint *> *)constraintsGreaterThanOrEqualToConstant:(UIEdgeInsets)c;
-- (NSArray<NSLayoutConstraint *> *)constraintsLessThanOrEqualToConstant:(UIEdgeInsets)c;
+- (NSArray<NSLayoutConstraint *> *)constraintsEqualToConstant:(UIEdgeInsets)c NS_SWIFT_NAME( constraints(equalToConstant:) );
+- (NSArray<NSLayoutConstraint *> *)constraintsGreaterThanOrEqualToConstant:(UIEdgeInsets)c NS_SWIFT_NAME( constraints(greaterThanOrEqualToConstant:) );
+- (NSArray<NSLayoutConstraint *> *)constraintsLessThanOrEqualToConstant:(UIEdgeInsets)c NS_SWIFT_NAME( constraints(lessThanOrEqualToConstant:) );
 
 /* These methods return an array of inactive constraints of the form
  thisVariable = view + constant.
  */
-- (NSArray<NSLayoutConstraint *> *)constraintsEqualToView:(UIView *)view constant:(UIEdgeInsets)c;
-- (NSArray<NSLayoutConstraint *> *)constraintsGreaterThanOrEqualToView:(UIView *)view constant:(UIEdgeInsets)c;
-- (NSArray<NSLayoutConstraint *> *)constraintsLessThanOrEqualToView:(UIView *)view constant:(UIEdgeInsets)c;
+- (NSArray<NSLayoutConstraint *> *)constraintsEqualToView:(UIView *)view constant:(UIEdgeInsets)c NS_SWIFT_NAME( constraints(equalToView:constant:) );
+- (NSArray<NSLayoutConstraint *> *)constraintsGreaterThanOrEqualToView:(UIView *)view constant:(UIEdgeInsets)c NS_SWIFT_NAME( constraints(greaterThanOrEqualToView:constant:) );
+- (NSArray<NSLayoutConstraint *> *)constraintsLessThanOrEqualToView:(UIView *)view constant:(UIEdgeInsets)c NS_SWIFT_NAME( constraints(lessThanOrEqualToView:constant:) );
 
 @end
 

--- a/Pod/Classes/ABLayoutSizeDimension.h
+++ b/Pod/Classes/ABLayoutSizeDimension.h
@@ -15,37 +15,37 @@ NS_ASSUME_NONNULL_BEGIN
 /* These methods return a pair of inactive constraints of the form
  thisVariable = constant.
  */
-- (NSArray<NSLayoutConstraint *> *)constraintsEqualToConstant:(CGSize)c;
-- (NSArray<NSLayoutConstraint *> *)constraintsGreaterThanOrEqualToConstant:(CGSize)c;
-- (NSArray<NSLayoutConstraint *> *)constraintsLessThanOrEqualToConstant:(CGSize)c;
+- (NSArray<NSLayoutConstraint *> *)constraintsEqualToConstant:(CGSize)c NS_SWIFT_NAME( constraints(equalToConstant:) );
+- (NSArray<NSLayoutConstraint *> *)constraintsGreaterThanOrEqualToConstant:(CGSize)c NS_SWIFT_NAME( constraints(greaterThanOrEqualToConstant:) );
+- (NSArray<NSLayoutConstraint *> *)constraintsLessThanOrEqualToConstant:(CGSize)c NS_SWIFT_NAME( constraints(lessThanOrEqualToConstant:) );
 
 /* These methods return a pair of inactive constraints of the form
  thisAnchor = otherAnchor.
  */
-- (NSArray<NSLayoutConstraint *> *)constraintsEqualToAnchor:(ABLayoutSizeDimension *)anchor;
-- (NSArray<NSLayoutConstraint *> *)constraintsGreaterThanOrEqualToAnchor:(ABLayoutSizeDimension *)anchor;
-- (NSArray<NSLayoutConstraint *> *)constraintsLessThanOrEqualToAnchor:(ABLayoutSizeDimension *)anchor;
+- (NSArray<NSLayoutConstraint *> *)constraintsEqualToAnchor:(ABLayoutSizeDimension *)anchor NS_SWIFT_NAME( constraints(equalTo:) );
+- (NSArray<NSLayoutConstraint *> *)constraintsGreaterThanOrEqualToAnchor:(ABLayoutSizeDimension *)anchor NS_SWIFT_NAME( constraints(greaterThanOrEqualTo:) );
+- (NSArray<NSLayoutConstraint *> *)constraintsLessThanOrEqualToAnchor:(ABLayoutSizeDimension *)anchor NS_SWIFT_NAME( constraints(lessThanOrEqualTo:) );
 
 /* These methods return a pair of inactive constraints of the form
  thisAnchor = otherAnchor + constant.
  */
-- (NSArray<NSLayoutConstraint *> *)constraintsEqualToAnchor:(ABLayoutSizeDimension *)anchor constant:(CGSize)c;
-- (NSArray<NSLayoutConstraint *> *)constraintsGreaterThanOrEqualToAnchor:(ABLayoutSizeDimension *)anchor constant:(CGSize)c;
-- (NSArray<NSLayoutConstraint *> *)constraintsLessThanOrEqualToAnchor:(ABLayoutSizeDimension *)anchor constant:(CGSize)c;
+- (NSArray<NSLayoutConstraint *> *)constraintsEqualToAnchor:(ABLayoutSizeDimension *)anchor constant:(CGSize)c NS_SWIFT_NAME( constraints(equalTo:constant:) );
+- (NSArray<NSLayoutConstraint *> *)constraintsGreaterThanOrEqualToAnchor:(ABLayoutSizeDimension *)anchor constant:(CGSize)c NS_SWIFT_NAME( constraints(greaterThanOrEqualTo:constant:) );
+- (NSArray<NSLayoutConstraint *> *)constraintsLessThanOrEqualToAnchor:(ABLayoutSizeDimension *)anchor constant:(CGSize)c NS_SWIFT_NAME( constraints(lessThanOrEqualTo:constant:) );
 
 /* These methods return a pair of inactive constraints of the form
  thisAnchor = otherAnchor * multiplier.
  */
-- (NSArray<NSLayoutConstraint *> *)constraintsEqualToAnchor:(ABLayoutSizeDimension *)anchor multiplier:(CGSize)m;
-- (NSArray<NSLayoutConstraint *> *)constraintsGreaterThanOrEqualToAnchor:(ABLayoutSizeDimension *)anchor multiplier:(CGSize)m;
-- (NSArray<NSLayoutConstraint *> *)constraintsLessThanOrEqualToAnchor:(ABLayoutSizeDimension *)anchor multiplier:(CGSize)m;
+- (NSArray<NSLayoutConstraint *> *)constraintsEqualToAnchor:(ABLayoutSizeDimension *)anchor multiplier:(CGSize)m NS_SWIFT_NAME( constraints(equalTo:multiplier:) );
+- (NSArray<NSLayoutConstraint *> *)constraintsGreaterThanOrEqualToAnchor:(ABLayoutSizeDimension *)anchor multiplier:(CGSize)m NS_SWIFT_NAME( constraints(greaterThanOrEqualTo:multiplier:) );
+- (NSArray<NSLayoutConstraint *> *)constraintsLessThanOrEqualToAnchor:(ABLayoutSizeDimension *)anchor multiplier:(CGSize)m NS_SWIFT_NAME( constraints(lessThanOrEqualTo:multiplier:) );
 
 /* These methods return a pair of inactive constraints of the form
  thisAnchor = otherAnchor * multiplier + constant.
  */
-- (NSArray<NSLayoutConstraint *> *)constraintsEqualToAnchor:(ABLayoutSizeDimension *)anchor multiplier:(CGSize)m constant:(CGSize)c;
-- (NSArray<NSLayoutConstraint *> *)constraintsGreaterThanOrEqualToAnchor:(ABLayoutSizeDimension *)anchor multiplier:(CGSize)m constant:(CGSize)c;
-- (NSArray<NSLayoutConstraint *> *)constraintsLessThanOrEqualToAnchor:(ABLayoutSizeDimension *)anchor multiplier:(CGSize)m constant:(CGSize)c;
+- (NSArray<NSLayoutConstraint *> *)constraintsEqualToAnchor:(ABLayoutSizeDimension *)anchor multiplier:(CGSize)m constant:(CGSize)c NS_SWIFT_NAME( constraints(equalTo:multiplier:constant:) );
+- (NSArray<NSLayoutConstraint *> *)constraintsGreaterThanOrEqualToAnchor:(ABLayoutSizeDimension *)anchor multiplier:(CGSize)m constant:(CGSize)c NS_SWIFT_NAME( constraints(greaterThanOrEqualTo:multiplier:constant:) );
+- (NSArray<NSLayoutConstraint *> *)constraintsLessThanOrEqualToAnchor:(ABLayoutSizeDimension *)anchor multiplier:(CGSize)m constant:(CGSize)c NS_SWIFT_NAME( constraints(lessThanOrEqualTo:multiplier:constant:) );
 
 @end
 


### PR DESCRIPTION
I try to use MissingAnchors in Xcode8/swift3 project.
When using in swift, it is nice to follow swift3 naming rule ([Apple docs](https://developer.apple.com/reference/uikit/nslayoutanchor?language=swift)).
I set `NS_SWIFT_NAME` macro.