### PR TITLE
Fix typo of ABLayoutAnchor

### DIFF
--- a/Pod/Classes/ABLayoutAnchor/ABLayoutAnchor.h
+++ b/Pod/Classes/ABLayoutAnchor/ABLayoutAnchor.h
@@ -65,7 +65,7 @@ NS_ASSUME_NONNULL_BEGIN
  thisVariable = constant.
  */
 - (NSLayoutConstraint *)constraintEqualToConstant:(CGFloat)c NS_SWIFT_NAME( constraint(equalToConstant:) );
-- (NSLayoutConstraint *)constraintGreaterThanOrEqualToConstant:(CGFloat)c NS_SWIFT_NAME( constraint(greaterThanOrEqualeToConstant:) );
+- (NSLayoutConstraint *)constraintGreaterThanOrEqualToConstant:(CGFloat)c NS_SWIFT_NAME( constraint(greaterThanOrEqualToConstant:) );
 - (NSLayoutConstraint *)constraintLessThanOrEqualToConstant:(CGFloat)c NS_SWIFT_NAME( constraint(lessThanOrEqualToConstant:) );
 
 /* These methods return an inactive constraint of the form


### PR DESCRIPTION
Hi, thank you for nice work.
I found some issue when using ABLayoutAnchor.
ABLayoutAnchor contains Typo name function. I fix it to correct one.

```swift
-- (NSLayoutConstraint *)constraintGreaterThanOrEqualToConstant:(CGFloat)c NS_SWIFT_NAME( constraint(greaterThanOrEqualeToConstant:) );
+- (NSLayoutConstraint *)constraintGreaterThanOrEqualToConstant:(CGFloat)c NS_SWIFT_NAME( constraint(greaterThanOrEqualToConstant:) );
```