### PR TITLE
Fix crash in ios 8 of UIView+ABLayoutAnchor

### DIFF
--- a/Pod/Classes/ABLayoutAnchor/UIView+ABLayoutAnchor.m
+++ b/Pod/Classes/ABLayoutAnchor/UIView+ABLayoutAnchor.m
@@ -15,7 +15,7 @@
 @implementation UIView (ABLayoutAnchor)
 
 + (void)load {
-    if (![UIView instanceMethodForSelector:@selector(topAnchor)]) {
+    if (![UIView resolveInstanceMethod:@selector(topAnchor)]) {
         SEL selectors[] = {
             @selector(ab_leadingAnchor),
             @selector(ab_trailingAnchor),


### PR DESCRIPTION
Hi, thank you for nice work.
I found some crash bug in ios 8 when using UIView+ABLayoutAnchor. 
I fix it to correct one by using simple check method.

```swift
-- if (![UIView instanceMethodForSelector:@selector(topAnchor)]) {
+- if (![UIView resolveInstanceMethod:@selector(topAnchor)]) {
```